### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 branches:
   only:
   - master

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 	</contributors>
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/trackmate-extras</archive>
 		</mailingList>
 	</mailingLists>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>26.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -70,15 +70,15 @@
 		<license.licenseName>GPL_3</license.licenseName>
 		<license.copyrightOwners>My Company, Inc.</license.copyrightOwners>
 
-		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
-		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		<!-- NB: Deploy releases to the SciJava Maven repository. -->
+		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>
 
 	<repositories>
 		<!-- NB: for project parent -->
 		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with some other minor POM updates and improvements.